### PR TITLE
Fix dirtyCow filename mismatch (dirtyCow.c=>dirtycow.c)

### DIFF
--- a/app/CMakeLists.txt
+++ b/app/CMakeLists.txt
@@ -9,6 +9,6 @@ set(CMAKE_LIBRARY_OUTPUT_DIRECTORY      "${CMAKE_CURRENT_SOURCE_DIR}/src/main/li
 
 add_library( dirtyCow
              SHARED
-             src/main/jni/dirtyCow.c )
+             src/main/jni/dirtycow.c )
 target_link_libraries(  dirtyCow
                         log)


### PR DESCRIPTION
This breaked build on case-sensitive FS (Linux)